### PR TITLE
fix: center home content vertically in main area

### DIFF
--- a/app/components/main/HomeContent.tsx
+++ b/app/components/main/HomeContent.tsx
@@ -66,8 +66,8 @@ export default function HomeContent() {
   ];
 
   return (
-    <div className="flex w-full h-auto justify-center">
-      <div className="flex flex-col lg:justify-center w-10/12 md:w-8/12 h-auto pt-10">
+    <div className="flex w-full min-h-full justify-center">
+      <div className="flex flex-col w-10/12 md:w-8/12 h-auto my-auto py-10">
         <header className="flex flex-col pb-12">
           <h1 className="text-5xl text-tabs-content-text font-[mono-space-neon] mb-2">Narae Hyeon</h1>
           <h2 className="text-2xl sm:text-3xl text-tabs-content-text-secondary">Software Engineer</h2>


### PR DESCRIPTION
## Summary 

Fixes the home page content sticking to the top of the viewport with a large empty area below it on desktop.

## Problem

`HomeContent` had `lg:justify-center` on the content column to center it vertically, but its wrapper was `h-auto` — the wrapper only grew to the content's own height, so there was no free space to distribute and the centering silently did nothing.

## Fix

- Wrapper: `h-auto` → `min-h-full` so it fills the content area and creates the space to center within.
- Content column: `lg:justify-center` → `my-auto`, which centers when free   space exists and safely collapses to top-aligned scrolling when content is taller than the screen (avoids the top-clipping issue `justify-center` has inside overflow containers).
- `pt-10` → `py-10` for symmetric padding so the visual center is exact.

## Verification

Verified with browser screenshots at 1920×1080, 1280×800, and 375×812: content is vertically centered on desktop/wide, mobile still scrolls from the top as before, and there are no console errors.